### PR TITLE
Update index.js

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -200,6 +200,11 @@ RedisCluster.prototype.sendClusterCommand = function (command, args, callback) {
     }
 
     var key = args[0];
+
+    if ((command === 'eval' || command === 'evalsha') && parseInt(args[1])>0) {
+        key = args[2];
+    }
+
     var slot = this.getSlot(key);
     this.getConnectionBySlot(slot, function (err, conn) {
         if (err) {


### PR DESCRIPTION
This fix is ugly, It would be better to have a list of allowed command in cluster mode with a function to know which argument should be considered as the key. But as a quick fix to allow proper use of eval and evalsha command in cluster mode, it can do the job.
It makes as much sense as supporting the multi interface as the lua script execution in redis is supported by the cluster and the natural replacement for the multi interface in the future. It is also more performant.
All the keys sent to the script should be on the same slot to get it to work (as for the multi interface) so just considering the first key, if it is given, is fine. In case of the other keys are not from the same slot, redis will return the cross slot error as usual.
If there is no key for a script then we can let the hash of the script deciding on which node running it as it can be run freely on any node.